### PR TITLE
Add option to set max levels displayed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,12 @@ Simplify navigation in large markdown files.
     let g:markdrawerPasteBelow = "p"
     let g:markdrawerIncrease = "+"
     let g:markdrawerDecrease = "-"
-    ```
+```
+
+* Set the maxium number of levels to display:
+    ```vim
+    let g:markdown_drawer_max_levels
+```
 
 ### License
 MIT

--- a/autoload/levels.vim
+++ b/autoload/levels.vim
@@ -42,7 +42,9 @@ endfunction
 
 function! Header(outline, line, lNum) 
   let l:hCount = matchend(a:line, '\m\C^#\+')
-  if l:hCount > 0
+  let l:max_levels = get(g:, 'markdown_drawer_max_levels', 0)
+
+  if l:hCount > 0 && l:hCount <= l:max_levels
     call add(a:outline, {'fileLineNum': a:lNum, 'active': 0, 'header':  HeaderName(a:line, l:hCount) })
   endif
 endfunction


### PR DESCRIPTION
This addresses the comment from reddit found here: https://www.reddit.com/r/vim/comments/b1xjtj/wrote_my_first_vim_plugin_feedback_welcomed/eip4c4n

To set the max level, just define `g:markdown_drawer_max_levels` in your rc file:

```vim
let g:markdown_drawer_max_levels = 2
```

will not allow headers beyond level 2 in the drawer.